### PR TITLE
Ignore new typos

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,3 +104,5 @@ lines-after-imports = 2
 [tool.typos.default.extend-words]
 # short for Stratonovich used in various names
 strat = "strat"
+# scipy.stats.sem (standard error of the mean)
+sems = "sems"


### PR DESCRIPTION
`typos` started complaining about "sems", which seems valid, so this just adds it to the ignore list.